### PR TITLE
radcal build: add build script for windows release build

### DIFF
--- a/Build/intel_win_64/make_radcal.bat
+++ b/Build/intel_win_64/make_radcal.bat
@@ -1,0 +1,6 @@
+@echo off
+Title Building release radcal for 64 bit Windows
+
+call ..\Scripts\setup_intel_compilers.bat
+
+make VPATH="../../Source" -f ..\makefile intel_win_64

--- a/Build/intel_win_64/make_radcal.sh
+++ b/Build/intel_win_64/make_radcal.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-platform=intel64
-dir=`pwd`
-target=${dir##*/}
-
-source $IFORT_COMPILER/bin/compilervars.sh $platform
-
-echo Building $target
-make -j4 DEBUG=1 VPATH="../../Source" -f ../makefile $target


### PR DESCRIPTION
fyi: there was not a build batch file for the windows release version (it was a bash script).  this pull request creates a make_release.bat script for intel_windows_64 .
