### PR TITLE
RadCal User Guide: Remove old style package

### DIFF
--- a/Documentation/commoncommands.tex
+++ b/Documentation/commoncommands.tex
@@ -41,8 +41,6 @@
 \newcommand{\ct}{\tt\small} % eventually will be deprecated due to http://www.tex.ac.uk/cgi-bin/texfaq2html?label=2letterfontcmd
 \newcommand{\textct}[1]{\texttt{\small #1}}
 
-\usepackage{tocstyle} % Fix table of contents sections from overlapping section titles
-\usetocstyle{standard}
 \usepackage{listings}
 \usepackage{textcomp}
 \definecolor{lbcolor}{rgb}{0.96,0.96,0.96}


### PR DESCRIPTION
The User's Guide would not compile because of some outdated style file.