### PR TITLE
Fix typo in Effective kappa equation

### DIFF
--- a/Documentation/Band_Models_Chapter.tex
+++ b/Documentation/Band_Models_Chapter.tex
@@ -466,7 +466,7 @@ where $L$ is the total path length given in cm. The bounds of integration in Eq.
 
 Formally, $\kappa_{\rm e}$ is calculated from:
 \be\label{eq:effective_epsilon}
-   \kappa_{\rm e} = -\dfrac{1}{L} \ln\left(\dfrac{\displaystyle\int_{\om_{\rm min}}^{\om_{\rm max}}{I_{\om}(L)  - I_{\rm b,\om}(T_g)\; \d \om}   }{\displaystyle\int_{\om_{\rm min}}^{\om_{\rm max}}{ I_{\rm b,\om}(T_w)-I_{\rm b,\om}(T_w) \; \d \om}  } \right).
+   \kappa_{\rm e} = -\dfrac{1}{L} \ln\left(\dfrac{\displaystyle\int_{\om_{\rm min}}^{\om_{\rm max}}{I_{\om}(L)  - I_{\rm b,\om}(T_g)\; \d \om}   }{\displaystyle\int_{\om_{\rm min}}^{\om_{\rm max}}{ I_{\rm b,\om}(T_w)-I_{\rm b,\om}(T_g) \; \d \om}  } \right).
 \ee
 Note that $\kappa_{\rm e}$ has the units of cm$^{-1}$. The effective absorption coefficient is calculated for homogeneous and non-homogeneous cases. For the latter, the gas temperature $T_g$ used in Eq.~\ref{eq:effective_epsilon} is the path-average temperature:
 \be\label{eq::Path_avg_temp}


### PR DESCRIPTION
Denominator had wrong temperature in second term